### PR TITLE
Give the user control over the tooltip position (above/below)

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -33,11 +33,14 @@ import 'shape_clipper.dart';
 import 'showcase_widget.dart';
 import 'tooltip_widget.dart';
 
+enum TooltipPosition { above, below }
+
 class Showcase extends StatefulWidget {
   @override
   final GlobalKey key;
 
   final Widget child;
+  final TooltipPosition tooltipPosition;
   final String? title;
   final String? description;
   final ShapeBorder? shapeBorder;
@@ -73,6 +76,7 @@ class Showcase extends StatefulWidget {
     required this.child,
     this.title,
     required this.description,
+    required this.tooltipPosition,
     this.shapeBorder,
     this.overlayColor = Colors.black45,
     this.overlayOpacity = 0.75,
@@ -113,6 +117,7 @@ class Showcase extends StatefulWidget {
     required this.container,
     required this.height,
     required this.width,
+    this.tooltipPosition = TooltipPosition.above,
     this.title,
     this.description,
     this.shapeBorder,
@@ -309,6 +314,7 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
               ),
               ToolTipWidget(
                 position: position,
+                tooltipPosition: widget.tooltipPosition,
                 offset: offset,
                 screenSize: screenSize,
                 title: widget.title,

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -26,9 +26,11 @@ import 'package:flutter/material.dart';
 
 import 'get_position.dart';
 import 'measure_size.dart';
+import 'showcase.dart';
 
 class ToolTipWidget extends StatefulWidget {
   final GetPosition? position;
+  final TooltipPosition tooltipPosition;
   final Offset? offset;
   final Size? screenSize;
   final String? title;
@@ -48,6 +50,7 @@ class ToolTipWidget extends StatefulWidget {
 
   ToolTipWidget(
       {this.position,
+      required this.tooltipPosition,
       this.offset,
       this.screenSize,
       this.title,
@@ -70,20 +73,6 @@ class ToolTipWidget extends StatefulWidget {
 
 class _ToolTipWidgetState extends State<ToolTipWidget> {
   Offset? position;
-
-  bool isCloseToTopOrBottom(Offset position) {
-    var height = 120.0;
-    height = widget.contentHeight ?? height;
-    return (widget.screenSize!.height - position.dy) <= height;
-  }
-
-  String findPositionForContent(Offset position) {
-    if (isCloseToTopOrBottom(position)) {
-      return 'ABOVE';
-    } else {
-      return 'BELOW';
-    }
-  }
 
   double _getTooltipWidth() {
     final titleStyle = widget.titleTextStyle ??
@@ -174,8 +163,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
   @override
   Widget build(BuildContext context) {
     position = widget.offset;
-    final contentOrientation = findPositionForContent(position!);
-    final contentOffsetMultiplier = contentOrientation == "BELOW" ? 1.0 : -1.0;
+    final contentOrientation = widget.tooltipPosition;
+    final contentOffsetMultiplier =
+        contentOrientation == TooltipPosition.below ? 1.0 : -1.0;
     ToolTipWidget.isArrowUp = contentOffsetMultiplier == 1.0;
 
     final contentY = ToolTipWidget.isArrowUp


### PR DESCRIPTION
Changes in this PR:
- Remove tooltip position calculations methods
- Add enum tooltipPosition {above,below}
- Allow users to choose themselves if the tooltip should be above or below the target widget